### PR TITLE
iOS: Samples Update and better instantiation

### DIFF
--- a/samples/Sample.iOS/Controllers/SampleController.cs
+++ b/samples/Sample.iOS/Controllers/SampleController.cs
@@ -25,6 +25,14 @@ namespace Sample {
 			View = view;
 		}
 
+		public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations ()
+		{
+			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Phone)
+				return UIInterfaceOrientationMask.Landscape;
+			else
+				return UIInterfaceOrientationMask.Portrait;
+		}
+
 		public override void ViewDidLoad ()
 		{
 			base.ViewDidLoad ();
@@ -36,6 +44,7 @@ namespace Sample {
 			if (true) { // Customization activated.
 				view.Signature.Caption.Text = "Authorization Signature";
 				view.Signature.Caption.Font = UIFont.FromName ("Marker Felt", 16f);
+
 				view.Signature.SignaturePrompt.Text = "☛";
 				view.Signature.SignaturePrompt.Font = UIFont.FromName ("Helvetica", 32f);
 				view.Signature.BackgroundColor = UIColor.FromRGB (255, 255, 200); // a light yellow.
@@ -43,7 +52,7 @@ namespace Sample {
 				view.Signature.BackgroundImageView.Image = UIImage.FromBundle ("logo-galaxy-black-64.png");
 				view.Signature.BackgroundImageView.Alpha = 0.0625f;
 				view.Signature.BackgroundImageView.ContentMode = UIViewContentMode.ScaleToFill;
-				view.Signature.BackgroundImageView.Frame = new System.Drawing.RectangleF (20, 20, 256, 256);
+				view.Signature.BackgroundImageView.Frame = view.Frame;
 
 				// Modify shadow
 				view.Signature.Layer.ShadowOffset = new System.Drawing.SizeF (0, 0);

--- a/samples/Sample.iOS/Info.plist
+++ b/samples/Sample.iOS/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleVersion</key>
 	<string>0.0.1</string>
 	<key>MinimumOSVersion</key>
-	<string>6.0</string>
+	<string>7.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/samples/Sample.iOS/Sample.csproj
+++ b/samples/Sample.iOS/Sample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
-    <ProductVersion>10.0.0</ProductVersion>
+    <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{733E5CA3-D51E-48A9-81C8-5509C0BA90CF}</ProjectGuid>
     <ProjectTypeGuids>{6BC8ED88-2882-458C-8E55-DFD12B67127B};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/samples/Sample.iOS/Views/SampleView.cs
+++ b/samples/Sample.iOS/Views/SampleView.cs
@@ -23,21 +23,33 @@ namespace Sample {
 		{
 			BackgroundColor = UIColor.White;
 
+			Frame = UIScreen.MainScreen.ApplicationFrame;
+
+			var padding = 10f;
+			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
+				padding = 84f;
+
+			Signature = new SignaturePadView ();
+			Signature.AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight;
+			Signature.Frame = new RectangleF(padding, padding + 20, Frame.Width - (2 * padding), Frame.Height - 46 - (2 * padding));
+
+
 			//Create the save button
 			btnSave = UIButton.FromType (UIButtonType.RoundedRect);
+			btnSave.Frame = new RectangleF (30, Frame.Height - 40, 100f, 44f);
+			btnSave.AutoresizingMask = UIViewAutoresizing.FlexibleRightMargin | UIViewAutoresizing.FlexibleTopMargin;
 			btnSave.SetTitle ("Save", UIControlState.Normal);
 
 			//Create the load button
 			btnLoad = UIButton.FromType (UIButtonType.RoundedRect);
+			btnLoad.Frame = new RectangleF (Frame.Width - 130, Frame.Height - 40, 100f, 44f);
+			btnLoad.AutoresizingMask = UIViewAutoresizing.FlexibleLeftMargin | UIViewAutoresizing.FlexibleTopMargin;
 			btnLoad.SetTitle ("Load Last", UIControlState.Normal);
 			btnLoad.TouchUpInside += (sender, e) => {
 				if (points != null)
 					Signature.LoadPoints (points);
-			};
+			};		
 
-			Frame = UIScreen.MainScreen.ApplicationFrame;
-
-			Signature = new SignaturePadView ();
 			//Using different layouts for the iPhone and iPad, so setup device specific requirements here.
 			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Phone) {
 
@@ -63,6 +75,8 @@ namespace Sample {
 
 				//Create the UIImageView to display a saved signature.
 				imageView = new UIImageView();
+				imageView.Frame = Signature.Frame;
+
 				AddSubview(imageView);
 			}
 			TranslatesAutoresizingMaskIntoConstraints = false;
@@ -71,46 +85,6 @@ namespace Sample {
 			AddSubview (Signature);
 			AddSubview (btnSave);
 			AddSubview (btnLoad);
-		}
-
-		public override void LayoutSubviews ()
-		{
-			if (new Version(MonoTouch.Constants.Version) >= new Version (7, 0))
-			{
-				var frame = Frame;
-
-				var width = UIApplication.SharedApplication.StatusBarOrientation.HasFlag(UIDeviceOrientation.Portrait)
-					? frame.Size.Width
-						: frame.Size.Width - UIApplication.SharedApplication.StatusBarFrame.Width ;
-
-				var height = UIApplication.SharedApplication.StatusBarOrientation.HasFlag (UIDeviceOrientation.Portrait)
-					? frame.Size.Height - UIApplication.SharedApplication.StatusBarFrame.Height 
-						: frame.Size.Height;
-
-				var x = UIApplication.SharedApplication.StatusBarOrientation.HasFlag (UIDeviceOrientation.Portrait)
-					? 0
-						: frame.Location.X + UIApplication.SharedApplication.StatusBarFrame.Width;
-
-				var y = UIApplication.SharedApplication.StatusBarOrientation.HasFlag (UIDeviceOrientation.Portrait)
-					? frame.Location.Y + UIApplication.SharedApplication.StatusBarFrame.Height
-						: 0;
-
-				Frame = new RectangleF (x, y, width, height);
-			}
-
-			///Using different layouts for the iPhone and iPad, so setup device specific requirements here.
-			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Phone)
-				Signature.Frame = new RectangleF (10, 10, Bounds.Width - 20, Bounds.Height - 60);
-			else {
-				Signature.Frame = new RectangleF (84, 84, Bounds.Width - 168, Bounds.Width / 2);
-				imageView.Frame = new RectangleF (84, Signature.Frame.Height + 168,
-				                                   Frame.Width - 168, Frame.Width / 2);
-			}
-
-			//Button locations are based on the Frame, so must have their own frames set after the view's
-			//Frame has been set.
-			btnSave.Frame = new RectangleF (10, Bounds.Height - 40, 120, 37);
-			btnLoad.Frame = new RectangleF (Bounds.Width - 130, Bounds.Height - 40, 120, 37);
 		}
 	}
 }

--- a/src/SignaturePad.iOS/SignaturePadView.cs
+++ b/src/SignaturePad.iOS/SignaturePadView.cs
@@ -26,6 +26,7 @@ namespace SignaturePad {
 		UILabel xLabel;
 		UIButton btnClear;
 		UIImageView imageView;
+		UIImageView backgroundImageView;
 		#endregion
 
 		UIBezierPath currentPath;
@@ -87,7 +88,11 @@ namespace SignaturePad {
 		/// <value>The signature prompt.</value>
 		public UILabel SignaturePrompt {
 			get { return xLabel; }
-			set { xLabel = value; }
+			set { 
+				xLabel = value; 
+				if (xLabel.Superview == null)
+					AddSubview (xLabel);
+			}
 		}
 
 		/// <summary>
@@ -99,7 +104,11 @@ namespace SignaturePad {
 		/// <value>The caption.</value>
 		public UILabel Caption {
 			get { return lblSign; }
-			set { lblSign = value; }
+			set { 
+				lblSign = value; 
+				if (lblSign.Superview == null)
+					AddSubview (lblSign);
+			}
 		}
 
 		/// <summary>
@@ -116,7 +125,14 @@ namespace SignaturePad {
 		///  for the signature pad.
 		/// </summary>
 		/// <value>The background image view.</value>
-		public UIImageView BackgroundImageView { get; private set; }
+		public UIImageView BackgroundImageView { 
+			get { return backgroundImageView; }
+			set {
+				backgroundImageView = value;
+				if (backgroundImageView.Superview == null)
+					AddSubview (backgroundImageView);
+			}
+		}
 
 		/// <summary>
 		/// Gets the label that clears the pad when clicked.
@@ -167,8 +183,8 @@ namespace SignaturePad {
 			Layer.ShadowRadius = 2f;
 
 			#region Add Subviews
-			BackgroundImageView = new UIImageView ();
-			AddSubview (BackgroundImageView);
+			backgroundImageView = new UIImageView ();
+			AddSubview (backgroundImageView);
 
 			//Add an image that covers the entire signature view, used to display already drawn
 			//elements instead of having to redraw them every time the user touches the screen.

--- a/src/SignaturePad.iOS/SignaturePadView.cs
+++ b/src/SignaturePad.iOS/SignaturePadView.cs
@@ -619,20 +619,24 @@ namespace SignaturePad {
 
 		public override void LayoutSubviews ()
 		{
+			var w = Bounds.Width;
+			var h = Bounds.Height;
+
 			lblSign.SizeToFit ();
 			xLabel.SizeToFit ();
 			btnClear.SizeToFit ();
 
-			imageView.Frame = new RectangleF (0, 0, Bounds.Width, Bounds.Height);
+			imageView.Frame = new RectangleF (0, 0, w, h);
 
-			lblSign.Frame = new RectangleF ((Bounds.Width / 2) - (lblSign.Frame.Width / 2), Bounds.Height - lblSign.Frame.Height - 3, 
+			lblSign.Frame = new RectangleF ((w / 2) - (lblSign.Frame.Width / 2), h - lblSign.Frame.Height - 3, 
 			                                lblSign.Frame.Width, lblSign.Frame.Height);
+			backgroundImageView.Frame = imageView.Frame;
 
-			signatureLine.Frame = new RectangleF (10, Bounds.Height - signatureLine.Frame.Height - 5 - lblSign.Frame.Height, Bounds.Width - 20, 1);
+			signatureLine.Frame = new RectangleF (10, h - signatureLine.Frame.Height - 5 - lblSign.Frame.Height, w - 20, 1);
 
-			xLabel.Frame = new RectangleF (10, Bounds.Height - xLabel.Frame.Height - signatureLine.Frame.Height - 2 - lblSign.Frame.Height, 
+			xLabel.Frame = new RectangleF (10, h - xLabel.Frame.Height - signatureLine.Frame.Height - 2 - lblSign.Frame.Height, 
 			                               xLabel.Frame.Width, xLabel.Frame.Height);
-			btnClear.Frame = new RectangleF (Bounds.Width - 41 - lblSign.Frame.Height, 10, 31, 14);
+			btnClear.Frame = new RectangleF (w - 41 - lblSign.Frame.Height, 10, 31, 14);
 		}
 	}
 }


### PR DESCRIPTION
Updated the iOS sample to better support rotation, also now you can better instantiate SignaturePadView like this (as per issue #3 ): 

```csharp
var signature = new SignaturePadView (View.Frame) {
        StrokeWidth = 3f,
        SignaturePrompt = new UILabel {Text="foo"},
    };
```