### PR TITLE
Prevent handled events from propagating.

### DIFF
--- a/src/SignaturePad.Android/SignaturePadView.cs
+++ b/src/SignaturePad.Android/SignaturePadView.cs
@@ -587,6 +587,9 @@ namespace SignaturePad {
 
 			switch (e.Action) {
 			case MotionEventActions.Down:
+                // don't allow the event to propagate because we're handling it here
+                Parent.RequestDisallowInterceptTouchEvent(true);
+
 				lastX = touchX;
 				lastY = touchY;
 
@@ -610,7 +613,10 @@ namespace SignaturePad {
 					(int) (dirtyRect.Bottom + 1));
 				break;
 			case MotionEventActions.Up:
-				handleTouch (e);
+                // don't allow the event to propagate because we're handling it here
+                Parent.RequestDisallowInterceptTouchEvent(true);
+
+                handleTouch(e);
 				currentPath = smoothedPathWithGranularity (20, out currentPoints);
 
 				//Add the current path and points to their respective lists.


### PR DESCRIPTION
If events are allowed to propagate, then the signature view will not function correctly inside a scroll view. That is, the scroll view will also receive the events and will therefore scroll.

This PR fixes this issue for Android (I am not using this control in iOS so cannot speak to whether something similar is required there).
