### PR TITLE
Expose Clear() method so the pad can be cleared using a method

### DIFF
--- a/src/SignaturePad.Forms.Platform.Shared/SignaturePadRenderer.cs
+++ b/src/SignaturePad.Forms.Platform.Shared/SignaturePadRenderer.cs
@@ -67,6 +67,7 @@ namespace SignaturePad.Forms.Droid
                 e.OldElement.IsBlankRequested -= OnIsBlankRequested;
                 e.OldElement.PointsRequested -= OnPointsRequested;
                 e.OldElement.PointsSpecified -= OnPointsSpecified;
+                e.OldElement.ClearRequested -= OnClearRequested;
             }
 
             if (e.NewElement != null)
@@ -76,6 +77,7 @@ namespace SignaturePad.Forms.Droid
                 e.NewElement.IsBlankRequested += OnIsBlankRequested;
                 e.NewElement.PointsRequested += OnPointsRequested;
                 e.NewElement.PointsSpecified += OnPointsSpecified;
+                e.NewElement.ClearRequested += OnClearRequested;
 
                 UpdateAll();
             }
@@ -176,6 +178,14 @@ namespace SignaturePad.Forms.Droid
             if (ctrl != null)
             {
                 ctrl.LoadPoints(e.Points.Select(p => new NativePoint((float)p.X, (float)p.Y)).ToArray());
+            }
+        }
+
+        private void OnClearRequested (object sender, System.EventArgs e)
+        {
+            var ctrl = Control;
+            if (ctrl != null) {
+                ctrl.Clear ();
             }
         }
 

--- a/src/SignaturePad.Forms/SignaturePadView.cs
+++ b/src/SignaturePad.Forms/SignaturePadView.cs
@@ -96,6 +96,11 @@ namespace SignaturePad.Forms
             return args.ImageStreamTask;
         }
 
+        public void Clear ()
+        {
+            ClearRequested?.Invoke (this, null);
+        }
+
         private IEnumerable<Point> GetSignaturePoints()
         {
             var args = new PointsEventArgs();
@@ -119,6 +124,7 @@ namespace SignaturePad.Forms
         internal event EventHandler<IsBlankRequestedEventArgs> IsBlankRequested;
         internal event EventHandler<PointsEventArgs> PointsRequested;
         internal event EventHandler<PointsEventArgs> PointsSpecified;
+        internal event EventHandler<EventArgs> ClearRequested;
 
         internal class ImageStreamRequestedEventArgs : EventArgs
         {


### PR DESCRIPTION
There is a Clear signature within the pad area. However, if a user wants to have a Clear button outside the pad area, the Forms component does not expose the Clear() method.

Made changes to expose the Clear() method so that can be invoked from an action outside of the pad.