### PR TITLE
Fix NullReferenceException on navigation for UWP

### DIFF
--- a/src/SignaturePad.Forms.Platform.Shared/SignaturePadRenderer.cs
+++ b/src/SignaturePad.Forms.Platform.Shared/SignaturePadRenderer.cs
@@ -62,7 +62,7 @@ namespace SignaturePad.Forms.Droid
         {
             base.OnElementChanged(e);
 
-            if (Control == null)
+            if (Control == null && e.NewElement != null)
             {
                 // Instantiate the native control and assign it to the Control property
 #if __ANDROID__


### PR DESCRIPTION
Thanks for pushing out the UWP integration. Unfortunately, I encounter the following NullReferenceException during navigation from a Forms page on UWP:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Xamarin.Forms.Platform.UWP.VisualElementRenderer`2.SetNativeControl(TNativeElement control)
   at SignaturePad.Forms.UWP.SignaturePadRenderer.OnElementChanged(ElementChangedEventArgs`1 e)
   at Xamarin.Forms.Platform.UWP.VisualElementRenderer`2.SetElement(VisualElement element)
   at Xamarin.Forms.Platform.UWP.VisualElementRenderer`2.Dispose(Boolean disposing)
   at Xamarin.Forms.Platform.UWP.VisualElementRenderer`2.Dispose()
   at Xamarin.Forms.Platform.UWP.VisualElementExtensions.Cleanup(VisualElement self)
   at Xamarin.Forms.Platform.UWP.PageRenderer.Dispose(Boolean disposing)
   at Xamarin.Forms.Platform.UWP.VisualElementRenderer`2.Dispose()
   at Xamarin.Forms.Platform.UWP.VisualElementExtensions.Cleanup(VisualElement self)
   at Xamarin.Forms.Platform.UWP.Platform.<SetCurrent>d__45.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.<>c.<ThrowAsync>b__6_0(Object state)
   at System.Threading.WinRTSynchronizationContext.Invoker.InvokeCore()
```