### PR TITLE
Update PCL Project Profile Number

### DIFF
--- a/samples/Sample.Forms/Samples/Samples.csproj
+++ b/samples/Sample.Forms/Samples/Samples.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>Samples</RootNamespace>
     <AssemblyName>Samples</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile78</TargetFrameworkProfile>
+    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <NuGetPackageImportStamp>


### PR DESCRIPTION
Portable Class Library project profile 78 doesn't support System.Net.Http. Recommending the profile number be changed to 111. Source information provided below:

- Xamarin's Matt Ward, "The Portable Class Library project template's default profile has been changed from 78 to 111."
- Xamarin's Matt Ward, "The System.Net.Http 4.0.3 NuGet package does not support PCL profile 78. Looking inside the NuGet package it supports PCL profile 111. If you switch your PCL profile to 111 you should be able to add that NuGet package."
[source](https://forums.xamarin.com/discussion/86067/system-net-http-could-not-install-package-system-net-http-4-3-0-you-are-trying-to-install-this-pa)