### PR TITLE
Fixed ScrollView problem on iOS

### DIFF
--- a/src/SignaturePad.iOS/InkPresenter.cs
+++ b/src/SignaturePad.iOS/InkPresenter.cs
@@ -28,6 +28,10 @@ namespace Xamarin.Controls
 		{
 			Opaque = false;
 		}
+		
+		// If you put SignaturePad inside a ScrollView, this line of code prevent that the gesture inside 
+		// an InkPresenter are dispatched to the ScrollView below
+		public override bool GestureRecognizerShouldBegin(UIGestureRecognizer gestureRecognizer) => false;
 
 		public override void TouchesBegan (NSSet touches, UIEvent evt)
 		{


### PR DESCRIPTION
Also with the latest update, if the SignaturePad is inside a ScrollView on iOS, the touch event were passed to the ScrollView and was impossible to use the signature component.