### PR TITLE
Improved MVVM Support

### DIFF
--- a/samples/Sample.Forms/Samples/Helpers/CaptureSignatureBehaviorBase.cs
+++ b/samples/Sample.Forms/Samples/Helpers/CaptureSignatureBehaviorBase.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using Xamarin.Forms;
+
+using SignaturePad.Forms;
+
+namespace Samples
+{
+	public class CaptureSignatureBehaviorBase : Behavior<SignaturePadView>
+	{
+		private bool updating;
+		private SignaturePadView associated;
+
+		protected override void OnAttachedTo (SignaturePadView bindable)
+		{
+			base.OnAttachedTo (bindable);
+
+			associated = bindable;
+			UpdateBindingContext (bindable, EventArgs.Empty);
+
+			bindable.Cleared += OnSignatureChanged;
+			bindable.StrokeCompleted += OnSignatureChanged;
+			bindable.BindingContextChanged += UpdateBindingContext;
+		}
+
+		protected override void OnDetachingFrom (SignaturePadView bindable)
+		{
+			bindable.Cleared -= OnSignatureChanged;
+			bindable.StrokeCompleted -= OnSignatureChanged;
+			bindable.BindingContextChanged -= UpdateBindingContext;
+
+			BindingContext = null;
+			associated = null;
+
+			base.OnDetachingFrom (bindable);
+		}
+
+		protected virtual void UpdateSignaturePad (SignaturePadView bindable, BindableProperty property, object oldValue, object newValue)
+		{
+		}
+
+		protected virtual void UpdateBehavior (SignaturePadView signaturePad)
+		{
+		}
+
+		protected void OnPropertyChanged (BindableObject bindable, BindableProperty property, object oldValue, object newValue)
+		{
+			var behavior = bindable as CaptureSignatureBehaviorBase;
+
+			if (!behavior.updating)
+			{
+				behavior.updating = true;
+				behavior.UpdateSignaturePad (behavior.associated, property, oldValue, newValue);
+				behavior.updating = false;
+			}
+		}
+
+		private void UpdateBindingContext (object sender, EventArgs e)
+		{
+			var signaturePad = sender as SignaturePadView;
+
+			BindingContext = signaturePad.BindingContext;
+		}
+
+		private void OnSignatureChanged (object sender, EventArgs e)
+		{
+			var signaturePad = sender as SignaturePadView;
+
+			if (!updating)
+			{
+				updating = true;
+				UpdateBehavior (signaturePad);
+				updating = false;
+			}
+		}
+
+		public static BindableProperty.BindingPropertyChangedDelegate CreatePropertyChanged (BindableProperty property)
+		{
+			return OnPropertyChanged;
+
+			void OnPropertyChanged (BindableObject bindable, object oldValue, object newValue)
+			{
+				var behavior = bindable as CaptureSignatureBehaviorBase;
+				behavior.OnPropertyChanged (bindable, property, oldValue, newValue);
+			}
+		}
+	}
+}

--- a/samples/Sample.Forms/Samples/Helpers/CaptureSignaturePointsBehavior.cs
+++ b/samples/Sample.Forms/Samples/Helpers/CaptureSignaturePointsBehavior.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms;
+
+using SignaturePad.Forms;
+
+namespace Samples
+{
+	public class CaptureSignaturePointsBehavior : CaptureSignatureBehaviorBase
+	{
+		public static readonly BindableProperty PointsProperty = BindableProperty.Create (
+			nameof (Points),
+			typeof (IEnumerable<Point>),
+			typeof (CaptureSignaturePointsBehavior),
+			default (IEnumerable<Point>),
+			BindingMode.TwoWay,
+			propertyChanged: CreatePropertyChanged (PointsProperty));
+
+		public IEnumerable<Point> Points
+		{
+			get => (IEnumerable<Point>)GetValue (PointsProperty);
+			set => SetValue (PointsProperty, value);
+		}
+
+		protected override void UpdateSignaturePad (SignaturePadView bindable, BindableProperty property, object oldValue, object newValue)
+		{
+			bindable.Points = newValue as IEnumerable<Point>;
+		}
+
+		protected override void UpdateBehavior (SignaturePadView signaturePad)
+		{
+			Points = signaturePad.Points;
+		}
+	}
+}

--- a/samples/Sample.Forms/Samples/Helpers/CaptureSignatureStrokesBehavior.cs
+++ b/samples/Sample.Forms/Samples/Helpers/CaptureSignatureStrokesBehavior.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms;
+
+using SignaturePad.Forms;
+
+namespace Samples
+{
+	public class CaptureSignatureStrokesBehavior : CaptureSignatureBehaviorBase
+	{
+		public static readonly BindableProperty StrokesProperty = BindableProperty.Create (
+			nameof (Strokes),
+			typeof (IEnumerable<IEnumerable<Point>>),
+			typeof (CaptureSignatureStrokesBehavior),
+			default (IEnumerable<IEnumerable<Point>>),
+			BindingMode.TwoWay,
+			propertyChanged: CreatePropertyChanged (StrokesProperty));
+
+		public IEnumerable<IEnumerable<Point>> Strokes
+		{
+			get => (IEnumerable<IEnumerable<Point>>)GetValue (StrokesProperty);
+			set => SetValue (StrokesProperty, value);
+		}
+
+		protected override void UpdateSignaturePad (SignaturePadView bindable, BindableProperty property, object oldValue, object newValue)
+		{
+			bindable.Strokes = newValue as IEnumerable<IEnumerable<Point>>;
+		}
+
+		protected override void UpdateBehavior (SignaturePadView signaturePad)
+		{
+			Strokes = signaturePad.Strokes;
+		}
+	}
+}

--- a/samples/Sample.Forms/Samples/Helpers/NotConverter.cs
+++ b/samples/Sample.Forms/Samples/Helpers/NotConverter.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Globalization;
+using Xamarin.Forms;
+
+namespace Samples
+{
+	public class NotConverter : IValueConverter
+	{
+		public object Convert (object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			return Equals (value, false);
+		}
+
+		public object ConvertBack (object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			return Equals (value, false);
+		}
+	}
+}

--- a/samples/Sample.Forms/Samples/MainPage.xaml
+++ b/samples/Sample.Forms/Samples/MainPage.xaml
@@ -1,10 +1,15 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+﻿<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:local="clr-namespace:Samples"
              xmlns:controls="clr-namespace:SignaturePad.Forms;assembly=SignaturePad.Forms"
              x:Class="Samples.MainPage"
              Title="Signature Pad">
+
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <local:NotConverter x:Key="NotConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
 
     <Grid x:Name="LayoutRoot" Padding="12">
 
@@ -16,21 +21,33 @@
 
         <ContentView Padding="1" BackgroundColor="#B8860B">
             <controls:SignaturePadView
-                x:Name="signatureView" StrokeCompleted="SignatureChanged" Cleared="SignatureChanged"
+                x:Name="signaturePadView"
+                StrokeCompletedCommand="{Binding StrokeCompletedCommand}"
+                ClearedCommand="{Binding ClearedCommand}"
                 CaptionTextColor="#B8860B" ClearTextColor="#B8860B" PromptTextColor="#B8860B"
-                SignatureLineColor="#B8860B" BackgroundColor="#FAFAD2" />
+                SignatureLineColor="#B8860B" BackgroundColor="#FAFAD2">
+                <controls:SignaturePadView.Behaviors>
+                    <local:CaptureSignaturePointsBehavior Points="{Binding CurrentSignature}" />
+                </controls:SignaturePadView.Behaviors>
+            </controls:SignaturePadView>
         </ContentView>
 
         <Button
-            x:Name="btnSave" Text="Save Vector" Clicked="SaveVectorClicked"
+            Text="Save Vector"
+            Command="{Binding SaveVectorCommand}"
+            IsEnabled="{Binding IsBlank, Source={Reference signaturePadView}, Converter={StaticResource NotConverter}}"
             HorizontalOptions="Start" VerticalOptions="End" Grid.Row="2" />
 
         <Button
-            x:Name="btnLoad" Text="Load Vector" Clicked="LoadVectorClicked"
+            Text="Load Vector"
+            Command="{Binding LoadVectorCommand}"
+            IsEnabled="{Binding HasSavedSignature}"
             HorizontalOptions="Center" VerticalOptions="End" Grid.Row="2" />
 
         <Button
-            x:Name="btnSaveImage" Text="Save Image" Clicked="SaveImageClicked"
+            Text="Save Image"
+            Command="{Binding SaveImageCommand}"
+            IsEnabled="{Binding IsBlank, Source={Reference signaturePadView}, Converter={StaticResource NotConverter}}"
             HorizontalOptions="End" VerticalOptions="End" Grid.Row="2" />
 
     </Grid>

--- a/samples/Sample.Forms/Samples/MainPage.xaml.cs
+++ b/samples/Sample.Forms/Samples/MainPage.xaml.cs
@@ -1,59 +1,14 @@
-﻿using System;
-using System.Linq;
-using Xamarin.Forms;
-
-using SignaturePad.Forms;
+﻿using Xamarin.Forms;
 
 namespace Samples
 {
 	public partial class MainPage : ContentPage
 	{
-		private Point[] points;
-
 		public MainPage ()
 		{
 			InitializeComponent ();
 
-			UpdateControls ();
-		}
-
-		private void UpdateControls ()
-		{
-			btnSave.IsEnabled = !signatureView.IsBlank;
-			btnSaveImage.IsEnabled = !signatureView.IsBlank;
-			btnLoad.IsEnabled = points != null;
-		}
-
-		private void SaveVectorClicked (object sender, EventArgs e)
-		{
-			points = signatureView.Points.ToArray ();
-			UpdateControls ();
-
-			DisplayAlert ("Signature Pad", "Vector signature saved to memory.", "OK");
-		}
-
-		private void LoadVectorClicked (object sender, EventArgs e)
-		{
-			signatureView.Points = points;
-		}
-
-		private async void SaveImageClicked (object sender, EventArgs e)
-		{
-			bool saved;
-			using (var bitmap = await signatureView.GetImageStreamAsync (SignatureImageFormat.Png, Color.Black, Color.White, 1f))
-			{
-				saved = await App.SaveSignature (bitmap, "signature.png");
-			}
-
-			if (saved)
-				await DisplayAlert ("Signature Pad", "Raster signature saved to the photo library.", "OK");
-			else
-				await DisplayAlert ("Signature Pad", "There was an error saving the signature.", "OK");
-		}
-
-		private void SignatureChanged (object sender, EventArgs e)
-		{
-			UpdateControls ();
+			BindingContext = new MainViewModel (signaturePadView.GetImageStreamAsync);
 		}
 	}
 }

--- a/samples/Sample.Forms/Samples/MainViewModel.cs
+++ b/samples/Sample.Forms/Samples/MainViewModel.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Xamarin.Forms;
+
+using SignaturePad.Forms;
+
+namespace Samples
+{
+	public class MainViewModel : BindableObject
+	{
+		private IEnumerable<Point> currentSignature;
+		private Point[] savedSignature;
+
+		public MainViewModel (Func<SignatureImageFormat, ImageConstructionSettings, Task<Stream>> getImageDelegate)
+		{
+			GetImageStreamAsync = getImageDelegate;
+
+			SaveVectorCommand = new Command (OnSaveVector);
+			LoadVectorCommand = new Command (OnLoadVector);
+			SaveImageCommand = new Command (OnSaveImage);
+		}
+
+		public IEnumerable<Point> CurrentSignature
+		{
+			get => currentSignature;
+			set
+			{
+				currentSignature = value;
+				OnPropertyChanged ();
+			}
+		}
+
+		public Point[] SavedSignature
+		{
+			get => savedSignature;
+			set
+			{
+				savedSignature = value;
+				OnPropertyChanged ();
+				OnPropertyChanged (nameof (HasSavedSignature));
+			}
+		}
+
+		public bool HasSavedSignature => savedSignature?.Length > 0;
+
+		public ICommand SaveVectorCommand { get; }
+
+		public ICommand LoadVectorCommand { get; }
+
+		public ICommand SaveImageCommand { get; }
+
+		private Func<SignatureImageFormat, ImageConstructionSettings, Task<Stream>> GetImageStreamAsync { get; }
+
+		private void OnSaveVector ()
+		{
+			SavedSignature = CurrentSignature.ToArray ();
+
+			DisplayAlert ("Vector signature saved to memory.");
+		}
+
+		private void OnLoadVector ()
+		{
+			CurrentSignature = SavedSignature;
+		}
+
+		private async void OnSaveImage ()
+		{
+			var settings = new ImageConstructionSettings
+			{
+				StrokeColor = Color.Black,
+				BackgroundColor = Color.White,
+				StrokeWidth = 1f
+			};
+
+			using (var bitmap = await GetImageStreamAsync (SignatureImageFormat.Png, settings))
+			{
+				var saved = await App.SaveSignature (bitmap, "signature.png");
+
+				if (saved)
+					DisplayAlert ("Raster signature saved to the photo library.");
+				else
+					DisplayAlert ("There was an error saving the signature.");
+			}
+		}
+
+		private void DisplayAlert (string message)
+		{
+			Application.Current.MainPage.DisplayAlert ("Signature Pad", message, "OK");
+		}
+	}
+}

--- a/samples/Sample.Forms/Samples/Samples.csproj
+++ b/samples/Sample.Forms/Samples/Samples.csproj
@@ -6,6 +6,10 @@
     <AssemblyName>Samples</AssemblyName>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\SignaturePad.Forms\SignaturePad.Forms.csproj" />
   </ItemGroup>

--- a/src/SignaturePad.Forms.Shared/ImageConstructionSettings.cs
+++ b/src/SignaturePad.Forms.Shared/ImageConstructionSettings.cs
@@ -105,8 +105,12 @@ namespace SignaturePad.Forms
 
 	public struct ImageConstructionSettings
 	{
-		public static readonly float DefaultStrokeWidth = 2f;
+		public static readonly bool DefaultShouldCrop = true;
+		public static readonly SizeOrScale DefaultSizeOrScale = 1f;
 		public static readonly Color DefaultStrokeColor = Color.Black;
+		public static readonly Color DefaultBackgroundColor = Color.Transparent;
+		public static readonly float DefaultStrokeWidth = 2f;
+		public static readonly float DefaultPadding = 5f;
 
 		public bool? ShouldCrop { get; set; }
 

--- a/src/SignaturePad.Forms.Shared/SignaturePadCanvasView.cs
+++ b/src/SignaturePad.Forms.Shared/SignaturePadCanvasView.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using System.Windows.Input;
 using Xamarin.Forms;
 
 namespace SignaturePad.Forms
@@ -20,6 +21,25 @@ namespace SignaturePad.Forms
 			typeof (float),
 			typeof (SignaturePadView),
 			ImageConstructionSettings.DefaultStrokeWidth);
+
+		public static readonly BindableProperty ClearedCommandProperty = BindableProperty.Create (
+			nameof (ClearedCommand),
+			typeof (ICommand),
+			typeof (SignaturePadView),
+			default (ICommand));
+
+		public static readonly BindableProperty StrokeCompletedCommandProperty = BindableProperty.Create (
+			nameof (StrokeCompletedCommand),
+			typeof (ICommand),
+			typeof (SignaturePadView),
+			default (ICommand));
+
+		internal static readonly BindablePropertyKey IsBlankPropertyKey = BindableProperty.CreateReadOnly (
+			nameof (IsBlank),
+			typeof (bool),
+			typeof (SignaturePadView),
+			true);
+		public static readonly BindableProperty IsBlankProperty = IsBlankPropertyKey.BindableProperty;
 
 		public bool IsBlank
 		{
@@ -48,6 +68,18 @@ namespace SignaturePad.Forms
 		{
 			get { return GetSignatureStrokes (); }
 			set { SetSignatureStrokes (value); }
+		}
+
+		public ICommand ClearedCommand
+		{
+			get => (ICommand)GetValue (ClearedCommandProperty);
+			set => SetValue (ClearedCommandProperty, value);
+		}
+
+		public ICommand StrokeCompletedCommand
+		{
+			get => (ICommand)GetValue (StrokeCompletedCommandProperty);
+			set => SetValue (StrokeCompletedCommandProperty, value);
 		}
 
 		/// <summary>
@@ -215,12 +247,31 @@ namespace SignaturePad.Forms
 
 		internal void OnStrokeCompleted ()
 		{
+			UpdateBindableProperties ();
+
 			StrokeCompleted?.Invoke (this, EventArgs.Empty);
+
+			if (StrokeCompletedCommand != null && StrokeCompletedCommand.CanExecute (null))
+			{
+				StrokeCompletedCommand.Execute (null);
+			}
 		}
 
 		internal void OnCleared ()
 		{
+			UpdateBindableProperties ();
+
 			Cleared?.Invoke (this, EventArgs.Empty);
+
+			if (ClearedCommand != null && ClearedCommand.CanExecute (null))
+			{
+				ClearedCommand.Execute (null);
+			}
+		}
+
+		private void UpdateBindableProperties ()
+		{
+			SetValue (IsBlankPropertyKey, IsBlank);
 		}
 
 		public event EventHandler StrokeCompleted;

--- a/src/SignaturePad.Shared/ImageConstructionSettings.cs
+++ b/src/SignaturePad.Shared/ImageConstructionSettings.cs
@@ -135,8 +135,12 @@ namespace Xamarin.Controls
 		internal static readonly NativeColor Transparent = NativeColor.FromArgb (0, 0, 0, 0);
 #endif
 
-		public static readonly float DefaultStrokeWidth = 2f;
+		public static readonly bool DefaultShouldCrop = true;
+		public static readonly SizeOrScale DefaultSizeOrScale = 1f;
 		public static readonly NativeColor DefaultStrokeColor = Black;
+		public static readonly NativeColor DefaultBackgroundColor = Transparent;
+		public static readonly float DefaultStrokeWidth = 2f;
+		public static readonly float DefaultPadding = 5f;
 
 		public bool? ShouldCrop { get; set; }
 
@@ -157,12 +161,12 @@ namespace Xamarin.Controls
 
 		internal void ApplyDefaults (float strokeWidth, NativeColor strokeColor)
 		{
-			ShouldCrop = ShouldCrop ?? true;
-			DesiredSizeOrScale = DesiredSizeOrScale ?? 1f;
+			ShouldCrop = ShouldCrop ?? DefaultShouldCrop;
+			DesiredSizeOrScale = DesiredSizeOrScale ?? DefaultSizeOrScale;
 			StrokeColor = StrokeColor ?? strokeColor;
-			BackgroundColor = BackgroundColor ?? Transparent;
+			BackgroundColor = BackgroundColor ?? DefaultBackgroundColor;
 			StrokeWidth = StrokeWidth ?? strokeWidth;
-			Padding = Padding ?? 5f;
+			Padding = Padding ?? DefaultPadding;
 		}
 	}
 }


### PR DESCRIPTION
This PR adds some new features as well as shows one example of making the signature pad more bindable.

**New Features**
 - the `IsBlank` property is now bindable
 - the `StrokeCompleted` event has a companion `StrokeCompletedCommand`
 - the `Cleared` event has a companion `ClearedCommand`

**Sample**
 - the Xamarin.Forms sample shows how the use of behaviors can make signature pad properties available to a MVVM view model.